### PR TITLE
add: バリデーション処理の追加

### DIFF
--- a/lib/Widget/qrScan.dart
+++ b/lib/Widget/qrScan.dart
@@ -1,10 +1,18 @@
+import 'dart:convert';
+
 import 'package:barcode_scan/barcode_scan.dart';
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 
 // 読み込み結果を表示するダイアログ
 Future<ScanResult> qrScan() async {
   try {
     var result = await BarcodeScanner.scan();
+    Map<String, dynamic> rowContent = json.decode(result.rawContent);
+
+    bool dateCheckResult = Validation.dateCheck(rowContent['date']);
+    bool strCheckResult = Validation.strCheck(rowContent['str']);
+
     return result;
   } on PlatformException catch (e) {
     var result = ScanResult(
@@ -19,3 +27,32 @@ Future<ScanResult> qrScan() async {
     return result;
   }
 }
+
+class Validation {
+  static bool dateCheck(content) {
+    DateTime now = DateTime(2021, 6, 1);
+    DateFormat outputFormat = DateFormat('yyyy/MM/dd');
+    String date = outputFormat.format(now);
+
+    return date == content ? true : false;
+  }
+
+  static bool strCheck(content) {
+    return content.contains('stamp');
+  }
+}
+/*
+ScanResult
+format:BarcodeFormat (qr)
+formatNote:""
+rawContent:"https://ja.wikipedia.org/"
+type:ResultType (Barcode)
+hashCode:120338450
+runtimeType:Type (ScanResult)
+format:BarcodeFormat (qr)
+formatNote:""
+rawContent:"https://ja.wikipedia.org/"
+type:ResultType (Barcode)
+hashCode:120338450
+runtimeType:Type (ScanResult)
+*/

--- a/lib/Widget/qrScan.dart
+++ b/lib/Widget/qrScan.dart
@@ -10,8 +10,10 @@ Future<ScanResult> qrScan() async {
     var result = await BarcodeScanner.scan();
     Map<String, dynamic> rowContent = json.decode(result.rawContent);
 
-    bool dateCheckResult = Validation.dateCheck(rowContent['date']);
-    bool strCheckResult = Validation.strCheck(rowContent['str']);
+    if (!Validation.dateCheck(rowContent['date']) ||
+        !Validation.strCheck(rowContent['str'])) {
+      result.rawContent = 'データが不正です';
+    }
 
     return result;
   } on PlatformException catch (e) {
@@ -37,22 +39,11 @@ class Validation {
     return date == content ? true : false;
   }
 
-  static bool strCheck(content) {
-    return content.contains('stamp');
+  static bool strCheck(String content) {
+    // 記号・半角を含まない
+    if (RegExp(r'^(?=.*[!-/:-@[-`{-~]).*$').hasMatch(content)) return false;
+    if (!content.contains('stamp')) return false;
+    if (content.contains('http')) return false;
+    return true;
   }
 }
-/*
-ScanResult
-format:BarcodeFormat (qr)
-formatNote:""
-rawContent:"https://ja.wikipedia.org/"
-type:ResultType (Barcode)
-hashCode:120338450
-runtimeType:Type (ScanResult)
-format:BarcodeFormat (qr)
-formatNote:""
-rawContent:"https://ja.wikipedia.org/"
-type:ResultType (Barcode)
-hashCode:120338450
-runtimeType:Type (ScanResult)
-*/

--- a/lib/Widget/qrScan.dart
+++ b/lib/Widget/qrScan.dart
@@ -10,7 +10,7 @@ Future<ScanResult> qrScan() async {
     var result = await BarcodeScanner.scan();
     Map<String, dynamic> rowContent = json.decode(result.rawContent);
 
-    if (!Validation.dateCheck(rowContent['date']) ||
+    if (!Validation.dateCheck(rowContent['date'], rowContent['time']) ||
         !Validation.strCheck(rowContent['str'])) {
       result.rawContent = 'データが不正です';
     }
@@ -31,12 +31,11 @@ Future<ScanResult> qrScan() async {
 }
 
 class Validation {
-  static bool dateCheck(content) {
-    DateTime now = DateTime(2021, 6, 1);
-    DateFormat outputFormat = DateFormat('yyyy/MM/dd');
-    String date = outputFormat.format(now);
-
-    return date == content ? true : false;
+  static bool dateCheck(date, time) {
+    DateTime verificationDate = DateTime(2021, 6, 1, 12, 0, 0);
+    if (date != DateFormat('yyyy/MM/dd').format(verificationDate)) return false;
+    if (time != DateFormat('HH:mm:ss').format(verificationDate)) return false;
+    return true;
   }
 
   static bool strCheck(String content) {

--- a/lib/Widget/qrScan.dart
+++ b/lib/Widget/qrScan.dart
@@ -14,7 +14,6 @@ Future<ScanResult> qrScan() async {
         !Validation.strCheck(rowContent['str'])) {
       result.rawContent = 'データが不正です';
     }
-
     return result;
   } on PlatformException catch (e) {
     var result = ScanResult(
@@ -30,6 +29,7 @@ Future<ScanResult> qrScan() async {
   }
 }
 
+// 読み込んだQRを検証するクラス
 class Validation {
   static bool dateCheck(date, time) {
     DateTime verificationDate = DateTime(2021, 6, 1, 12, 0, 0);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,11 +29,9 @@ dependencies:
   sqflite:
   path:
 
-
-
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
+  intl: ^0.15.7
   cupertino_icons: ^1.0.0
   barcode_scan: any
   flutter_native_splash: ^1.1.8+4
@@ -53,7 +51,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/test/qrScan_test.dart
+++ b/test/qrScan_test.dart
@@ -4,10 +4,13 @@ import 'package:stamp_app/Widget/qrScan.dart';
 void main() {
   group('qr content validation test', () {
     test('dateCheck validation true test', () {
-      expect(Validation.dateCheck('2021/06/01'), true);
+      expect(Validation.dateCheck('2021/06/01', '12:00:00'), true);
     });
-    test('dateCheck validation false test', () {
-      expect(Validation.dateCheck('2021/06/02'), false);
+    test('dateCheck validation date false test', () {
+      expect(Validation.dateCheck('2021/06/02', '12:00:00'), false);
+    });
+    test('dateCheck validation time false test', () {
+      expect(Validation.dateCheck('2021/06/01', '13:00:00'), false);
     });
     test('strCheck validation true test', () {
       expect(Validation.strCheck('stamp'), true);

--- a/test/qrScan_test.dart
+++ b/test/qrScan_test.dart
@@ -3,13 +3,20 @@ import 'package:stamp_app/Widget/qrScan.dart';
 
 void main() {
   group('qr content validation test', () {
-    test('dateCheck validation test', () {
+    test('dateCheck validation true test', () {
       expect(Validation.dateCheck('2021/06/01'), true);
     });
-
-    test('strCheck validation test', () {
+    test('dateCheck validation false test', () {
+      expect(Validation.dateCheck('2021/06/02'), false);
+    });
+    test('strCheck validation true test', () {
       expect(Validation.strCheck('stamp'), true);
     });
-
+    test('strCheck validation http test', () {
+      expect(Validation.strCheck('httpstamp'), false);
+    });
+    test('strCheck validation symbol test', () {
+      expect(Validation.strCheck('stamp()#%#'), false);
+    });
   });
 }

--- a/test/qrScan_test.dart
+++ b/test/qrScan_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:stamp_app/Widget/qrScan.dart';
+
+void main() {
+  group('qr content validation test', () {
+    test('dateCheck validation test', () {
+      expect(Validation.dateCheck('2021/06/01'), true);
+    });
+
+    test('strCheck validation test', () {
+      expect(Validation.strCheck('stamp'), true);
+    });
+
+  });
+}

--- a/test/qrScan_test.dart
+++ b/test/qrScan_test.dart
@@ -6,18 +6,22 @@ void main() {
     test('dateCheck validation true test', () {
       expect(Validation.dateCheck('2021/06/01', '12:00:00'), true);
     });
+    // 日付が異なる
     test('dateCheck validation date false test', () {
       expect(Validation.dateCheck('2021/06/02', '12:00:00'), false);
     });
+    // 時刻が異なる
     test('dateCheck validation time false test', () {
       expect(Validation.dateCheck('2021/06/01', '13:00:00'), false);
     });
     test('strCheck validation true test', () {
       expect(Validation.strCheck('stamp'), true);
     });
+    // httpが含まれる
     test('strCheck validation http test', () {
       expect(Validation.strCheck('httpstamp'), false);
     });
+    // 記号が含まれる
     test('strCheck validation symbol test', () {
       expect(Validation.strCheck('stamp()#%#'), false);
     });


### PR DESCRIPTION
不正なデータが無いかの判定をどうするか考え中
QRデータから送られてくる形式はとりあえずjsonを想定
※jsonをデコードするだけでなくBase64などからの変更が欲しそうだが今回は未実装

jsonサンプル
```
{
     "date": "2021/06/01",
     "time": "12:00:00", 
     "str": "stamp-app"
 }
```