### PR TITLE
update:プライバシーポリシー等の最下層に空白部分を追加

### DIFF
--- a/lib/View/home.dart
+++ b/lib/View/home.dart
@@ -398,7 +398,8 @@ class _HomeSamplePageState extends State<HomeSamplePage> {
               fit: BoxFit.contain,
               height: 50,
             ),
-            Container(padding: EdgeInsets.only(left: 200))
+            //画面下ににスタンプカードが被らないように
+            Expanded(child: Container(padding: EdgeInsets.only(left: 200))),
           ],
         ),
         actions: <Widget>[
@@ -424,7 +425,7 @@ class _HomeSamplePageState extends State<HomeSamplePage> {
         onPressed: _qrScan,
         backgroundColor: HexColor('00C2FF'),
       ),
-      body: Container(
+      body: SingleChildScrollView(
         child: Column(
           //mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: <Widget>[

--- a/lib/View/privacyPolicy.dart
+++ b/lib/View/privacyPolicy.dart
@@ -24,15 +24,22 @@ class _PrivacyPolicyPageState extends State<PrivacyPolicyPage> {
   @override
   Widget build(BuildContext context) {
     // Scaffoldは画面構成の基本Widget
+    //デバイスのサイズ取得
+    final double deviceHeight = MediaQuery.of(context).size.height;
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
         backgroundColor: HexColor('00C2FF'),
       ),
       body: ListView(
-        padding: const EdgeInsets.only(left: 20, right: 20),
+        padding: const EdgeInsets.only(
+          top: 20,
+          left: 20,
+          right: 20,
+          bottom: 50,
+        ),
         children: <Widget>[
-          SizedBox(height: 25),
+          SizedBox(height: deviceHeight * 0.2),
 
           Text(
               'このプライバシーポリシー（以下、「本ポリシー」といいます。）は、＿＿＿＿＿（以下、「当社」といいます。）がこのアプリケーション上で提供するサービス（以下、「本サービス」といいます。）の利用条件を定めるものです。登録ユーザーの皆さま（以下、「ユーザー」といいます。）には、本ポリシーに従って、本サービスをご利用いただきます。'),

--- a/lib/View/terms.dart
+++ b/lib/View/terms.dart
@@ -16,7 +16,12 @@ class _TermsPageState extends State<TermsPage> {
         backgroundColor: HexColor('00C2FF'),
       ),
       body: ListView(
-        padding: const EdgeInsets.only(left: 20, right: 20),
+        padding: const EdgeInsets.only(
+          top: 20,
+          left: 20,
+          right: 20,
+          bottom: 50,
+        ),
         children: <Widget>[
           SizedBox(height: 25),
 


### PR DESCRIPTION
プライバシーポリシー、利用規約、スタンプカードの三画面の最下層の部分にバーが被らないように修正しました。
