### PR TITLE
update:QRのpathのバリデーション追加

### DIFF
--- a/lib/Util/validation.dart
+++ b/lib/Util/validation.dart
@@ -20,4 +20,18 @@ class Validation {
     if (content.contains('http')) return false;
     return true;
   }
+
+  static bool pathCheck(String path, List<String> imagePaths) {
+    try {
+      String relative = path.substring(0, 2);
+      path = relative == "./"
+          ? path.substring(2)
+          : relative[0] == "/"
+              ? path.substring(1)
+              : path;
+      return imagePaths.contains(path) ? true : false;
+    } catch (e) {
+      return false;
+    }
+  }
 }

--- a/lib/Widget/qrScan.dart
+++ b/lib/Widget/qrScan.dart
@@ -11,10 +11,18 @@ Future<ScanResult> qrScan() async {
     if (result.type.name == "Cancelled") {
       return result;
     }
+
+    var manifestContent = await rootBundle.loadString('AssetManifest.json');
+    Map<String, dynamic> manifestMap = json.decode(manifestContent);
+    List<String> imagePaths = manifestMap.keys
+        .where((String key) => key.contains('images/'))
+        .toList();
+
     Map<String, dynamic> rowContent = json.decode(result.rawContent);
 
     if (!Validation.dateCheck(rowContent['createdAt']) ||
-        !Validation.strCheck(rowContent['data'])) {
+        !Validation.strCheck(rowContent['data']) ||
+        !Validation.pathCheck(rowContent['stampNum'], imagePaths)) {
       result.rawContent = 'データが不正です';
     }
     return result;

--- a/test/qrScan_test.dart
+++ b/test/qrScan_test.dart
@@ -5,6 +5,10 @@ import 'package:stamp_app/Util/validation.dart';
 void main() {
   group('QRコードのContentのValidation Test: ', () {
     final String stampCheckString = CheckString.ok.checkStringValue;
+    final List<String> imagePaths = [
+      "assets/images/stamp/flower-4.png",
+      "assets/images/stamp/none.png"
+    ];
     //QRの日付が今の日付より前
     test('QRの日付が今の日付より前 -> true', () {
       expect(Validation.dateCheck('2021/06/11 12:00:00'), true);
@@ -24,6 +28,34 @@ void main() {
     // 記号が含まれる
     test('記号が含まれる -> test', () {
       expect(Validation.strCheck(stampCheckString + '()#%#'), false);
+    });
+    // パスの先頭に./が含まれておりファイルが存在する
+    test('パスの先頭に./が含まれておりファイルが存在する -> true', () {
+      expect(
+          Validation.pathCheck(
+              "./assets/images/stamp/flower-4.png", imagePaths),
+          true);
+    });
+    // パスの先頭に/が含まれておりファイルが存在する
+    test('パスの先頭に/が含まれておりファイルが存在する -> true', () {
+      expect(
+          Validation.pathCheck("/assets/images/stamp/flower-4.png", imagePaths),
+          true);
+    });
+    // ファイルが存在する
+    test('ファイルが存在する -> true', () {
+      expect(
+          Validation.pathCheck("assets/images/stamp/flower-4.png", imagePaths),
+          true);
+    });
+    // ファイルが存在しない
+    test('ファイルが存在しない -> false', () {
+      expect(
+          Validation.pathCheck("assets/images/stamp/test", imagePaths), false);
+    });
+    // 文字列が0文字
+    test('文字列が0文字 -> false', () {
+      expect(Validation.pathCheck("", imagePaths), false);
     });
   });
 }


### PR DESCRIPTION
QRコードを読み込んだ際stampNumに画像のパスが含まれるがその画像が存在しない場合は不正なデータとして弾くように修正