### PR TITLE
空スタンプ内の数字が正しく表示されないバグの修正

### DIFF
--- a/lib/View/home.dart
+++ b/lib/View/home.dart
@@ -61,6 +61,8 @@ class _HomeSamplePageState extends State<HomeSamplePage> {
     List<Map<String, dynamic>> maps =
         await DbInterface.allSelect('Stamp', Stamp.database);
 
+    stampListLen = maps.length;
+
     stampList = List.generate(maps.length, (i) {
       return Stamp(
         id: maps[i]['id'],

--- a/lib/View/home.dart
+++ b/lib/View/home.dart
@@ -239,14 +239,11 @@ class _HomeSamplePageState extends State<HomeSamplePage> {
               child: Container(
             child: PageView(
               children: <Widget>[
-                Expanded(
-                  flex: 1,
-                  child: PageView(
-                    controller: controller,
-                    children: <Widget>[
-                      _slider(context, stampCheckString, deviceWidth)
-                    ],
-                  ),
+                PageView(
+                  controller: controller,
+                  children: <Widget>[
+                    _slider(context, stampCheckString, deviceWidth)
+                  ],
                 ),
               ],
               controller: controller,


### PR DESCRIPTION
アプリでQRコード読み取りアプリを再起動。再起動時、空のスタンプ内の数字が正しく表示されることが確認できた。
下の画像が修正後。

![FBキャプチャ](https://user-images.githubusercontent.com/58577218/125378421-a9b3da00-e3c9-11eb-8a28-7778594c8529.PNG)![sc](https://user-images.githubusercontent.com/58577218/125378176-4033cb80-e3c9-11eb-840e-06c98f4eb6a2.PNG)
