### PR TITLE
update:スタンプ詳細ダイアログ変更

### DIFF
--- a/lib/Widget/stampDialog.dart
+++ b/lib/Widget/stampDialog.dart
@@ -39,6 +39,7 @@ void stampDialog(BuildContext context, Stamp stamp) {
 }
 
 String dateFormat(createdAt) {
+  //createdAtを「yyyy年MM月DD日(E)　hh:mm:ss」という表記に変更する関数
   initializeDateFormatting('ja');
   String data = DateFormat.yMMMEd('ja').format(createdAt).toString() + "　";
   data += DateFormat.jms('ja').format(createdAt).toString();

--- a/lib/Widget/stampDialog.dart
+++ b/lib/Widget/stampDialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:stamp_app/models/stamp.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 
 // 読み込み結果を表示するダイアログ
 void stampDialog(BuildContext context, Stamp stamp) {
@@ -20,18 +22,7 @@ void stampDialog(BuildContext context, Stamp stamp) {
               ),
               ListTile(
                 title: Text("スタンプ読み込み日時"),
-                subtitle: Text(stamp.createdAt.year.toString() +
-                    "年" +
-                    stamp.createdAt.month.toString() +
-                    "月" +
-                    stamp.createdAt.day.toString() +
-                    "日 " +
-                    stamp.createdAt.hour.toString() +
-                    "時" +
-                    stamp.createdAt.minute.toString() +
-                    "分" +
-                    stamp.createdAt.second.toString() +
-                    "秒"),
+                subtitle: Text(dateFormat(stamp.createdAt)),
               ),
             ],
           ),
@@ -45,4 +36,11 @@ void stampDialog(BuildContext context, Stamp stamp) {
       );
     },
   );
+}
+
+String dateFormat(createdAt) {
+  initializeDateFormatting('ja');
+  String data = DateFormat.yMMMEd('ja').format(createdAt).toString() + "　";
+  data += DateFormat.jms('ja').format(createdAt).toString();
+  return data;
 }

--- a/lib/Widget/stampDialog.dart
+++ b/lib/Widget/stampDialog.dart
@@ -19,16 +19,19 @@ void stampDialog(BuildContext context, Stamp stamp) {
                     fit: BoxFit.fitWidth),
               ),
               ListTile(
-                title: Text("stampNum"),
-                subtitle: Text(stamp.stampNum.toString()),
-              ),
-              ListTile(
-                title: Text("data"),
-                subtitle: Text(stamp.data),
-              ),
-              ListTile(
-                title: Text("createAt"),
-                subtitle: Text(stamp.createdAt.toString()),
+                title: Text("スタンプ読み込み日時"),
+                subtitle: Text(stamp.createdAt.year.toString() +
+                    "年" +
+                    stamp.createdAt.month.toString() +
+                    "月" +
+                    stamp.createdAt.day.toString() +
+                    "日 " +
+                    stamp.createdAt.hour.toString() +
+                    "時" +
+                    stamp.createdAt.minute.toString() +
+                    "分" +
+                    stamp.createdAt.second.toString() +
+                    "秒"),
               ),
             ],
           ),


### PR DESCRIPTION
ユーザーの側に不要な画像パスとdataの項目は削除
CreatedAtをスタンプ読み込み日時に変更　日付データの表示を yyyy年MM月DD日 ah時mm分ss秒に変更
![スクリーンショット 2021-07-20 111354](https://user-images.githubusercontent.com/50894870/126251836-1731bf7b-37cd-454c-afd5-cc196add5b0e.png)
