### PR TITLE
fix:ダイアログ、アラートのボタンの統一化

### DIFF
--- a/lib/View/Setting.dart
+++ b/lib/View/Setting.dart
@@ -122,13 +122,14 @@ class _SettingPageState extends State<SettingPage> {
               Text(AppLocalizations.of(context)!.usedStamps + "\n\n$idsText"),
           actions: <Widget>[
             // ボタン領域
-            ElevatedButton(
+            OutlinedButton(
               child: Text(AppLocalizations.of(context)!.ok),
-              style: ElevatedButton.styleFrom(
+              style: OutlinedButton.styleFrom(
                 primary: Colors.blue,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),
                 ),
+                side: const BorderSide(color: Colors.blue),
               ),
               onPressed: () => Navigator.pop(context),
             ),

--- a/lib/View/Setting.dart
+++ b/lib/View/Setting.dart
@@ -103,6 +103,7 @@ class _SettingPageState extends State<SettingPage> {
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),
                     ),
+                    side: const BorderSide(color: Colors.blue),
                   ),
                   onPressed: () => Navigator.pop(context),
                 ),

--- a/lib/View/Setting.dart
+++ b/lib/View/Setting.dart
@@ -65,14 +65,13 @@ class _SettingPageState extends State<SettingPage> {
               onPressed: () => Navigator.pop(context),
             ),
 
-            OutlinedButton(
+            ElevatedButton(
               child: Text(AppLocalizations.of(context)!.ok),
-              style: OutlinedButton.styleFrom(
+              style: ElevatedButton.styleFrom(
                 primary: Colors.blue,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),
                 ),
-                side: const BorderSide(color: Colors.blue),
               ),
               onPressed: () => {Navigator.pop(context), _useStampDialog()},
             ),
@@ -97,9 +96,9 @@ class _SettingPageState extends State<SettingPage> {
                   AppLocalizations.of(context)!.littleStamps(exchangeSpnum)),
               actions: <Widget>[
                 // ボタン領域
-                ElevatedButton(
+                OutlinedButton(
                   child: Text(AppLocalizations.of(context)!.ok),
-                  style: ElevatedButton.styleFrom(
+                  style: OutlinedButton.styleFrom(
                     primary: Colors.blue,
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),

--- a/lib/View/Setting.dart
+++ b/lib/View/Setting.dart
@@ -65,13 +65,14 @@ class _SettingPageState extends State<SettingPage> {
               onPressed: () => Navigator.pop(context),
             ),
 
-            ElevatedButton(
+            OutlinedButton(
               child: Text(AppLocalizations.of(context)!.ok),
-              style: ElevatedButton.styleFrom(
+              style: OutlinedButton.styleFrom(
                 primary: Colors.blue,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),
                 ),
+                side: const BorderSide(color: Colors.blue),
               ),
               onPressed: () => {Navigator.pop(context), _useStampDialog()},
             ),

--- a/lib/Widget/stampDialog.dart
+++ b/lib/Widget/stampDialog.dart
@@ -24,20 +24,26 @@ void stampDialog(BuildContext context, Stamp stamp) {
                 title: Text(
                   AppLocalizations.of(context)!.stampLoadingDateTime,
                   style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
-                subtitle: Text(
-                  dateFormat(stamp.createdAt),
-                  style: TextStyle(color: Colors.black, fontSize: 15, height: 2)
-                  ),
+                ),
+                subtitle: Text(dateFormat(stamp.createdAt),
+                    style: TextStyle(
+                        color: Colors.black, fontSize: 15, height: 2)),
               ),
             ],
           ),
         ),
         actions: <Widget>[
-          TextButton(
+          OutlinedButton(
             child: Text(AppLocalizations.of(context)!.ok),
+            style: OutlinedButton.styleFrom(
+              primary: Colors.blue,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+              side: const BorderSide(color: Colors.blue),
+            ),
             onPressed: () => Navigator.of(context).pop(1),
-          ),
+          )
         ],
       );
     },


### PR DESCRIPTION
ダイアログのボタン
![bandicam 2021-07-28 12-29-04-514](https://user-images.githubusercontent.com/44780741/127259263-d2e4924d-5920-43df-84d4-f97fe2604657.jpg)
![bandicam 2021-07-28 12-29-11-307](https://user-images.githubusercontent.com/44780741/127259275-355d6dd6-c746-44ba-a222-0971173d302f.jpg)
を外枠ありにしました。